### PR TITLE
Implement trunk indicator mechanism for the loader task

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # We must fetch at least the immediate parents so that if this is
           # a pull request then we can checkout the head.

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Check Out Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -94,7 +94,7 @@ jobs:
           -e SOLA_SOLR_LIST=http://172.17.0.1:8983/solr/ \
           -e SEARCHER_URL=http://172.17.0.1:19531 \
           -e MILVUS_URL=172.17.0.1:19530 \
-          ghcr.io/shotit/shotit-worker-searcher:v0.9.10
+          ghcr.io/shotit/shotit-worker-searcher:v0.9.11
       - name: Docker run sorter
         env:
           CONTAINER_NETWORK: ${{ job.container.network }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -94,7 +94,7 @@ jobs:
           -e SOLA_SOLR_LIST=http://172.17.0.1:8983/solr/ \
           -e SEARCHER_URL=http://172.17.0.1:19531 \
           -e MILVUS_URL=172.17.0.1:19530 \
-          ghcr.io/shotit/shotit-worker-searcher:v0.9.11
+          ghcr.io/shotit/shotit-worker-searcher:v0.9.13
       - name: Docker run sorter
         env:
           CONTAINER_NETWORK: ${{ job.container.network }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -94,7 +94,7 @@ jobs:
           -e SOLA_SOLR_LIST=http://172.17.0.1:8983/solr/ \
           -e SEARCHER_URL=http://172.17.0.1:19531 \
           -e MILVUS_URL=172.17.0.1:19530 \
-          ghcr.io/shotit/shotit-worker-searcher:v0.9.13
+          ghcr.io/shotit/shotit-worker-searcher:v0.9.14
       - name: Docker run sorter
         env:
           CONTAINER_NETWORK: ${{ job.container.network }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,7 +19,7 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
 
   searcher:
     container_name: shotit-searcher
-    image: ghcr.io/shotit/shotit-worker-searcher:v0.9.11
+    image: ghcr.io/shotit/shotit-worker-searcher:v0.9.13
     restart: unless-stopped
     ports:
       - 19531:19531

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,6 @@ services:
     networks:
       shotit_net:
 
-
   redis:
     container_name: shotit-redis
     image: redis:latest
@@ -20,7 +19,6 @@ services:
       - ${REDIS_PORT}:6379
     networks:
       shotit_net:
-
 
   liresolr:
     container_name: shotit-liresolr
@@ -34,10 +32,9 @@ services:
     networks:
       shotit_net:
 
-
   searcher:
     container_name: shotit-searcher
-    image: ghcr.io/shotit/shotit-worker-searcher:v0.9.10
+    image: ghcr.io/shotit/shotit-worker-searcher:v0.9.11
     restart: unless-stopped
     ports:
       - 19531:19531
@@ -49,7 +46,6 @@ services:
     networks:
       shotit_net:
 
-
   sorter:
     container_name: shotit-sorter
     image: ghcr.io/shotit/shotit-sorter:v0.9.3
@@ -58,7 +54,6 @@ services:
       - 19532:19532
     networks:
       shotit_net:
-
 
   etcd:
     container_name: milvus-etcd
@@ -76,7 +71,6 @@ services:
       - "2379:2379"
     networks:
       shotit_net:
-
 
   minio:
     container_name: milvus-minio
@@ -98,25 +92,18 @@ services:
     depends_on:
       - "etcd"
     healthcheck:
-      test:
-        [
-          "CMD",
-          "curl",
-          "-f",
-          "http://localhost:9000/minio/health/live"
-        ]
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 30s
       timeout: 20s
       retries: 3
     networks:
       shotit_net:
 
-
   standalone:
     container_name: milvus-standalone
     image: milvusdb/milvus:v2.2.11
     restart: unless-stopped
-    command: [ "milvus", "run", "standalone" ]
+    command: ["milvus", "run", "standalone"]
     environment:
       ETCD_ENDPOINTS: etcd:2379
       MINIO_ADDRESS: minio:9000
@@ -131,7 +118,6 @@ services:
       - "minio"
     networks:
       shotit_net:
-
 
 networks:
   shotit_net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
 
   searcher:
     container_name: shotit-searcher
-    image: ghcr.io/shotit/shotit-worker-searcher:v0.9.13
+    image: ghcr.io/shotit/shotit-worker-searcher:v0.9.14
     restart: unless-stopped
     ports:
       - 19531:19531

--- a/src/worker/loaded.js
+++ b/src/worker/loaded.js
@@ -9,7 +9,9 @@ export default async (req, res) => {
   const { imdbID, filename } = req.params;
   console.log(`Loaded ${imdbID}/${filename}`);
   await knex(TRACE_ALGO).where("path", `${imdbID}/${filename}`).update({ status: "LOADED" });
-  await sendWorkerJobs(req.app.locals.knex, req.app.locals.workerPool);
+  if (req.headers["x-trunk-load"] === "true") {
+    await sendWorkerJobs(req.app.locals.knex, req.app.locals.workerPool);
+  }
   res.sendStatus(204);
 
   if (TELEGRAM_ID && TELEGRAM_URL) {

--- a/src/worker/send-worker-jobs.js
+++ b/src/worker/send-worker-jobs.js
@@ -86,7 +86,11 @@ const lookForLoadJobs = async (knex, workerPool, ws) => {
         selectedCore = selectCore.next().value;
       }
       console.log(`Loading ${file} to ${selectedCore}`);
-      ws.send(JSON.stringify({ file, core: selectedCore }));
+      if (i === 0) {
+        ws.send(JSON.stringify({ trunk: "true", file, core: selectedCore }));
+      } else {
+        ws.send(JSON.stringify({ trunk: "false", file, core: selectedCore }));
+      }
     }
   } else {
     workerPool.set(ws, { status: "READY", type: "load", file: "" });


### PR DESCRIPTION
Use trunk indicator to prevent loader thread being overwhelming, eight at most one batch

Only when the trunk indicator is true then begin sendWorkerJobs again when the type is 'load';

Sender: 
send-worker-jobs.js
![image](https://github.com/shotit/shotit-api/assets/27696701/4e699c27-106a-47b6-bc78-1398b4b5b471)

Receiver:
shotit-worker/loader.js
![image](https://github.com/shotit/shotit-api/assets/27696701/8fd89cb6-63ad-4b12-a1f0-a35236ff8daf)
![image](https://github.com/shotit/shotit-api/assets/27696701/07af105f-901a-4c36-997e-9c88a9431ca1)

After loader task:
![image](https://github.com/shotit/shotit-api/assets/27696701/326e7b32-6bc3-4de3-89a3-6cf27268446c)
